### PR TITLE
Add DNS names to items for MTR

### DIFF
--- a/zabbix-net-mtr/README.md
+++ b/zabbix-net-mtr/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 A Zabbix template for mtr (My traceroute). It uses all the new features from Zabbix 4.4 and 5.0 with Master Items, JSONpath processing and Dependent items.
-This template was built on Zabbix 5.0.x and Debian 9 & 10 amd64 with [mtr-tiny](https://packages.debian.org/stable/mtr-tiny).
+This template was built on Zabbix 7.0 and Ubuntu24 amd64 with [mtr-tiny](https://packages.debian.org/stable/mtr-tiny) and the built in `jq` utility.
 
 ## Installation
 
@@ -15,9 +15,13 @@ This template was built on Zabbix 5.0.x and Debian 9 & 10 amd64 with [mtr-tiny](
 ## Notes
 
 These files and templates were tested and created on Zabbix 4.4 & 5.0 and Debian Linux 9 & 10 amd64 with the package [mtr-tiny](https://packages.debian.org/stable/mtr-tiny).
-The XML file provided is exported from Zabbix 5.0.3.
+The XML file provided is exported from Zabbix 7.0.23.
 
-This template creates a Master item, which executes the script and receives the JSON output. From there on we have a Low-Level-Discovery rule, that discovery three item prototypes:
+This template creates a Master item, which executes the script and receives the JSON output. 
+
+> Note: By default, `mtr` combines the IP address and DNS names into a single `host` value in the JSON output. The `mtr.sh` script uses the `jq` utility to split the IP address and DNS names into their own values. These separated values get picked up by the Zabbix discovery rule for item naming.
+
+From there on we have a Low-Level-Discovery rule, that discovery three item prototypes:
 
 - Name of each Hop
 - Average RTT(ms) of each Hop
@@ -34,3 +38,4 @@ Parts of this Template are directly related to [a reddit discussion](https://www
 ## Changelog
 
 - 01 October 2020: initial commit.
+- 22 March 2026: Added DNS name data into MTR script output and item naming.

--- a/zabbix-net-mtr/Template_Net_MTR.xml
+++ b/zabbix-net-mtr/Template_Net_MTR.xml
@@ -29,7 +29,7 @@ https://packages.debian.org/stable/mtr-tiny</description>
                     <uuid>f7ab415867dd44669853cbe4989fdef8</uuid>
                     <name>MTR Trace Master</name>
                     <type>EXTERNAL</type>
-                    <key>mtr.sh[{HOST.IP}]</key>
+                    <key>mtr.sh[{$FIRST_TTL} {HOST.IP}]</key>
                     <history>0</history>
                     <value_type>TEXT</value_type>
                     <trends>0</trends>
@@ -78,7 +78,7 @@ https://packages.debian.org/stable/mtr-tiny</description>
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>mtr.sh[{HOST.IP}]</key>
+                                <key>mtr.sh[{$FIRST_TTL} {HOST.IP}]</key>
                             </master_item>
                             <tags>
                                 <tag>
@@ -88,29 +88,30 @@ https://packages.debian.org/stable/mtr-tiny</description>
                             </tags>
                         </item_prototype>
                         <item_prototype>
-                            <uuid>334c9585d9e34587913bf8d77620e4ef</uuid>
-                            <name>MTR Hop - State - {#HOP_ID}: {#HOP_NAME} ({#HOP_IP})</name>
+                            <uuid>fa8857769b6048adb4cbc2e4d0b7e42b</uuid>
+                            <name>MTR Hop - Best RTT(ms) - {#HOP_ID}: {#HOP_NAME} ({#HOP_IP})</name>
                             <type>DEPENDENT</type>
-                            <key>mtr.hop.host[{#HOP_IP}]</key>
+                            <key>mtr.hop.best[{#HOP_IP}]</key>
                             <delay>0</delay>
-                            <history>7d</history>
-                            <value_type>TEXT</value_type>
-                            <trends>0</trends>
+                            <history>14d</history>
+                            <value_type>FLOAT</value_type>
+                            <trends>180d</trends>
+                            <units>!ms</units>
                             <preprocessing>
                                 <step>
                                     <type>JSONPATH</type>
                                     <parameters>
-                                        <parameter>$.[?(@.count == &quot;{#HOP_ID}&quot;)].host.first()</parameter>
+                                        <parameter>$.[?(@.count == &quot;{#HOP_ID}&quot;)][&quot;Best&quot;].first()</parameter>
                                     </parameters>
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>mtr.sh[{HOST.IP}]</key>
+                                <key>mtr.sh[{$FIRST_TTL} {HOST.IP}]</key>
                             </master_item>
                             <tags>
                                 <tag>
                                     <tag>Application</tag>
-                                    <value>MTR Hosts</value>
+                                    <value>MTR Average RTT(ms)</value>
                                 </tag>
                             </tags>
                         </item_prototype>
@@ -133,7 +134,7 @@ https://packages.debian.org/stable/mtr-tiny</description>
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>mtr.sh[{HOST.IP}]</key>
+                                <key>mtr.sh[{$FIRST_TTL} {HOST.IP}]</key>
                             </master_item>
                             <tags>
                                 <tag>
@@ -142,9 +143,119 @@ https://packages.debian.org/stable/mtr-tiny</description>
                                 </tag>
                             </tags>
                         </item_prototype>
+                        <item_prototype>
+                            <uuid>23fc2f1f0ac446a08cac97db993cda56</uuid>
+                            <name>MTR Hop - StDev RTT(ms) - {#HOP_ID}: {#HOP_NAME} ({#HOP_IP})</name>
+                            <type>DEPENDENT</type>
+                            <key>mtr.hop.stdev[{#HOP_IP}]</key>
+                            <delay>0</delay>
+                            <history>14d</history>
+                            <value_type>FLOAT</value_type>
+                            <trends>180d</trends>
+                            <units>!ms</units>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.[?(@.count == &quot;{#HOP_ID}&quot;)][&quot;StDev&quot;].first()</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>mtr.sh[{$FIRST_TTL} {HOST.IP}]</key>
+                            </master_item>
+                            <tags>
+                                <tag>
+                                    <tag>Application</tag>
+                                    <value>MTR Average RTT(ms)</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>8ede2e86349248ef88e762b954c09def</uuid>
+                            <name>MTR Hop - Worst RTT(ms) - {#HOP_ID}: {#HOP_NAME} ({#HOP_IP})</name>
+                            <type>DEPENDENT</type>
+                            <key>mtr.hop.wrst[{#HOP_IP}]</key>
+                            <delay>0</delay>
+                            <history>14d</history>
+                            <value_type>FLOAT</value_type>
+                            <trends>180d</trends>
+                            <units>!ms</units>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.[?(@.count == &quot;{#HOP_ID}&quot;)][&quot;Wrst&quot;].first()</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>mtr.sh[{$FIRST_TTL} {HOST.IP}]</key>
+                            </master_item>
+                            <tags>
+                                <tag>
+                                    <tag>Application</tag>
+                                    <value>MTR Average RTT(ms)</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
                     </item_prototypes>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <uuid>02e74eeec1514d68961fdc436cd24973</uuid>
+                            <name>MTR Hop - {#HOP_ID}: {#HOP_NAME} ({#HOP_IP})</name>
+                            <show_work_period>NO</show_work_period>
+                            <show_triggers>NO</show_triggers>
+                            <graph_items>
+                                <graph_item>
+                                    <color>199C0D</color>
+                                    <calc_fnc>MIN</calc_fnc>
+                                    <item>
+                                        <host>Template Net MTR - Per-Hop</host>
+                                        <key>mtr.hop.avg[{#HOP_IP}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>1</sortorder>
+                                    <color>F63100</color>
+                                    <calc_fnc>MIN</calc_fnc>
+                                    <item>
+                                        <host>Template Net MTR - Per-Hop</host>
+                                        <key>mtr.hop.best[{#HOP_IP}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>2</sortorder>
+                                    <color>2774A4</color>
+                                    <calc_fnc>MIN</calc_fnc>
+                                    <item>
+                                        <host>Template Net MTR - Per-Hop</host>
+                                        <key>mtr.hop.loss[{#HOP_IP}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>3</sortorder>
+                                    <color>F7941D</color>
+                                    <calc_fnc>MIN</calc_fnc>
+                                    <item>
+                                        <host>Template Net MTR - Per-Hop</host>
+                                        <key>mtr.hop.stdev[{#HOP_IP}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>4</sortorder>
+                                    <color>FC6EA3</color>
+                                    <calc_fnc>MIN</calc_fnc>
+                                    <item>
+                                        <host>Template Net MTR - Per-Hop</host>
+                                        <key>mtr.hop.wrst[{#HOP_IP}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
                     <master_item>
-                        <key>mtr.sh[{HOST.IP}]</key>
+                        <key>mtr.sh[{$FIRST_TTL} {HOST.IP}]</key>
                     </master_item>
                     <lld_macro_paths>
                         <lld_macro_path>
@@ -166,6 +277,139 @@ https://packages.debian.org/stable/mtr-tiny</description>
                     </lld_macro_paths>
                 </discovery_rule>
             </discovery_rules>
+            <macros>
+                <macro>
+                    <macro>{$FIRST_TTL}</macro>
+                    <value>1</value>
+                </macro>
+            </macros>
+            <dashboards>
+                <dashboard>
+                    <uuid>e9c547e22e4f40e685f05d21568c622c</uuid>
+                    <name>MTR Dashboard</name>
+                    <pages>
+                        <page>
+                            <widgets>
+                                <widget>
+                                    <type>svggraph</type>
+                                    <name>Average RTT</name>
+                                    <width>72</width>
+                                    <height>6</height>
+                                    <fields>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>ds.0.color</name>
+                                            <value>0040FF</value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>ds.0.items.0</name>
+                                            <value>MTR Hop - Average RTT*</value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>IIZZO</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>righty</name>
+                                            <value>0</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>svggraph</type>
+                                    <name>Best RTT</name>
+                                    <y>6</y>
+                                    <width>72</width>
+                                    <height>6</height>
+                                    <fields>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>ds.0.color</name>
+                                            <value>2E7D32</value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>ds.0.items.0</name>
+                                            <value>MTR Hop - Best RTT*</value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>KGGHT</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>righty</name>
+                                            <value>0</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>svggraph</type>
+                                    <name>Worst RTT</name>
+                                    <y>12</y>
+                                    <width>72</width>
+                                    <height>6</height>
+                                    <fields>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>ds.0.color</name>
+                                            <value>FF0000</value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>ds.0.items.0</name>
+                                            <value>MTR Hop - Worst RTT*</value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>BKWTE</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>righty</name>
+                                            <value>0</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>svggraph</type>
+                                    <name>Standard Deviation</name>
+                                    <y>18</y>
+                                    <width>72</width>
+                                    <height>6</height>
+                                    <fields>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>ds.0.color</name>
+                                            <value>CC6600</value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>ds.0.items.0</name>
+                                            <value>MTR Hop - StDev*</value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>JCYIP</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>righty</name>
+                                            <value>0</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                            </widgets>
+                        </page>
+                    </pages>
+                </dashboard>
+            </dashboards>
         </template>
     </templates>
 </zabbix_export>

--- a/zabbix-net-mtr/Template_Net_MTR.xml
+++ b/zabbix-net-mtr/Template_Net_MTR.xml
@@ -1,141 +1,146 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
-    <version>5.0</version>
-    <date>2020-10-01T13:29:33Z</date>
-    <groups>
-        <group>
+    <version>7.0</version>
+    <template_groups>
+        <template_group>
+            <uuid>a571c0d144b14fd4a87a9d9b2aa9fcd6</uuid>
             <name>Templates/Applications</name>
-        </group>
-    </groups>
+        </template_group>
+    </template_groups>
     <templates>
         <template>
+            <uuid>7c6fab8b3b8048d685c1638702cc0ce4</uuid>
             <template>Template Net MTR</template>
             <name>Template Net MTR</name>
-            <description>Created by Marco Hofmann&#13;
-https://www.meinekleinefarm.net/zabbix-template-net-mtr-my-traceroute/&#13;
-https://github.com/xenadmin/zabbix-templates/tree/master/zabbix-net-mtr&#13;
-&#13;
-Tested on Debian Stable&#13;
-apt install mtr-tiny&#13;
+            <description>Created by Marco Hofmann
+https://www.meinekleinefarm.net/zabbix-template-net-mtr-my-traceroute/
+https://github.com/xenadmin/zabbix-templates/tree/master/zabbix-net-mtr
+
+Tested on Debian Stable
+apt install mtr-tiny
 https://packages.debian.org/stable/mtr-tiny</description>
             <groups>
                 <group>
                     <name>Templates/Applications</name>
                 </group>
             </groups>
-            <applications>
-                <application>
-                    <name>Master Items</name>
-                </application>
-                <application>
-                    <name>MTR Average RTT(ms)</name>
-                </application>
-                <application>
-                    <name>MTR Hosts</name>
-                </application>
-                <application>
-                    <name>MTR Loss%</name>
-                </application>
-            </applications>
             <items>
                 <item>
+                    <uuid>f7ab415867dd44669853cbe4989fdef8</uuid>
                     <name>MTR Trace Master</name>
                     <type>EXTERNAL</type>
                     <key>mtr.sh[{HOST.IP}]</key>
                     <history>0</history>
-                    <trends>0</trends>
                     <value_type>TEXT</value_type>
-                    <applications>
-                        <application>
-                            <name>Master Items</name>
-                        </application>
-                    </applications>
+                    <trends>0</trends>
                     <preprocessing>
                         <step>
                             <type>JSONPATH</type>
-                            <params>$.report.hubs</params>
+                            <parameters>
+                                <parameter>$.report.hubs</parameter>
+                            </parameters>
                         </step>
                     </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Master Items</value>
+                        </tag>
+                    </tags>
                 </item>
             </items>
             <discovery_rules>
                 <discovery_rule>
+                    <uuid>5b9a119fba5a476eb88b66a9bcbfb943</uuid>
                     <name>MTR Hops</name>
                     <type>DEPENDENT</type>
                     <key>mtr.hop.discovery</key>
                     <delay>0</delay>
                     <lifetime>1d</lifetime>
+                    <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
                     <item_prototypes>
                         <item_prototype>
-                            <name>MTR Hop {#HOP_ID}: {#HOP_HOST} - Average RTT(ms)</name>
+                            <uuid>953422bce9a64f4f981db2029f902e81</uuid>
+                            <name>MTR Hop - Average RTT(ms) - {#HOP_ID}: {#HOP_NAME} ({#HOP_IP})</name>
                             <type>DEPENDENT</type>
-                            <key>mtr.hop.avg[{#HOP_ID}]</key>
+                            <key>mtr.hop.avg[{#HOP_IP}]</key>
                             <delay>0</delay>
                             <history>14d</history>
-                            <trends>180d</trends>
                             <value_type>FLOAT</value_type>
+                            <trends>180d</trends>
                             <units>!ms</units>
-                            <applications>
-                                <application>
-                                    <name>MTR Average RTT(ms)</name>
-                                </application>
-                            </applications>
                             <preprocessing>
                                 <step>
                                     <type>JSONPATH</type>
-                                    <params>$.[?(@.count == &quot;{#HOP_ID}&quot;)][&quot;Avg&quot;].first()</params>
+                                    <parameters>
+                                        <parameter>$.[?(@.count == &quot;{#HOP_ID}&quot;)][&quot;Avg&quot;].first()</parameter>
+                                    </parameters>
                                 </step>
                             </preprocessing>
                             <master_item>
                                 <key>mtr.sh[{HOST.IP}]</key>
                             </master_item>
+                            <tags>
+                                <tag>
+                                    <tag>Application</tag>
+                                    <value>MTR Average RTT(ms)</value>
+                                </tag>
+                            </tags>
                         </item_prototype>
                         <item_prototype>
-                            <name>MTR Hop {#HOP_ID}: {#HOP_HOST}</name>
+                            <uuid>334c9585d9e34587913bf8d77620e4ef</uuid>
+                            <name>MTR Hop - State - {#HOP_ID}: {#HOP_NAME} ({#HOP_IP})</name>
                             <type>DEPENDENT</type>
-                            <key>mtr.hop.host[{#HOP_ID}]</key>
+                            <key>mtr.hop.host[{#HOP_IP}]</key>
                             <delay>0</delay>
                             <history>7d</history>
-                            <trends>0</trends>
                             <value_type>TEXT</value_type>
-                            <applications>
-                                <application>
-                                    <name>MTR Hosts</name>
-                                </application>
-                            </applications>
+                            <trends>0</trends>
                             <preprocessing>
                                 <step>
                                     <type>JSONPATH</type>
-                                    <params>$.[?(@.count == &quot;{#HOP_ID}&quot;)].host.first()</params>
+                                    <parameters>
+                                        <parameter>$.[?(@.count == &quot;{#HOP_ID}&quot;)].host.first()</parameter>
+                                    </parameters>
                                 </step>
                             </preprocessing>
                             <master_item>
                                 <key>mtr.sh[{HOST.IP}]</key>
                             </master_item>
+                            <tags>
+                                <tag>
+                                    <tag>Application</tag>
+                                    <value>MTR Hosts</value>
+                                </tag>
+                            </tags>
                         </item_prototype>
                         <item_prototype>
-                            <name>MTR Hop {#HOP_ID}: {#HOP_HOST} - ICMP Loss%</name>
+                            <uuid>9621c560fbcc4e68b62a484f555f12ca</uuid>
+                            <name>MTR Hop - ICMP Loss% - {#HOP_ID}: {#HOP_NAME} ({#HOP_IP})</name>
                             <type>DEPENDENT</type>
-                            <key>mtr.hop.loss[{#HOP_ID}]</key>
+                            <key>mtr.hop.loss[{#HOP_IP}]</key>
                             <delay>0</delay>
                             <history>14d</history>
-                            <trends>180d</trends>
                             <value_type>FLOAT</value_type>
+                            <trends>180d</trends>
                             <units>%</units>
-                            <applications>
-                                <application>
-                                    <name>MTR Loss%</name>
-                                </application>
-                            </applications>
                             <preprocessing>
                                 <step>
                                     <type>JSONPATH</type>
-                                    <params>$.[?(@.count == &quot;{#HOP_ID}&quot;)][&quot;Loss%&quot;].first()</params>
+                                    <parameters>
+                                        <parameter>$.[?(@.count == &quot;{#HOP_ID}&quot;)][&quot;Loss%&quot;].first()</parameter>
+                                    </parameters>
                                 </step>
                             </preprocessing>
                             <master_item>
                                 <key>mtr.sh[{HOST.IP}]</key>
                             </master_item>
+                            <tags>
+                                <tag>
+                                    <tag>Application</tag>
+                                    <value>MTR Loss%</value>
+                                </tag>
+                            </tags>
                         </item_prototype>
                     </item_prototypes>
                     <master_item>
@@ -149,6 +154,14 @@ https://packages.debian.org/stable/mtr-tiny</description>
                         <lld_macro_path>
                             <lld_macro>{#HOP_ID}</lld_macro>
                             <path>$.['count']</path>
+                        </lld_macro_path>
+                        <lld_macro_path>
+                            <lld_macro>{#HOP_IP}</lld_macro>
+                            <path>$.['ip']</path>
+                        </lld_macro_path>
+                        <lld_macro_path>
+                            <lld_macro>{#HOP_NAME}</lld_macro>
+                            <path>$.['name']</path>
                         </lld_macro_path>
                     </lld_macro_paths>
                 </discovery_rule>

--- a/zabbix-net-mtr/mtr.sh
+++ b/zabbix-net-mtr/mtr.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 IP=$1
-mtr  -r -c3 -b -j $IP | jq '
+FIRST_TTL=$2
+mtr  -r -c3 -b -j -f $FIRST_TTL $IP | jq '
 .report.hubs |= map(
   if (.host | test("\\(")) then
     . + {

--- a/zabbix-net-mtr/mtr.sh
+++ b/zabbix-net-mtr/mtr.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
 
 IP=$1
-mtr -r -c3 -w -b -p -j $IP
+mtr  -r -c3 -b -j $IP | jq '
+.report.hubs |= map(
+  if (.host | test("\\(")) then
+    . + {
+      name: (.host | capture("^(?<h>.+) \\((?<ip>.+)\\)$").h),
+      ip: (.host | capture("^(?<h>.+) \\((?<ip>.+)\\)$").ip)
+    }
+  else
+    . + {
+      name: "?",
+      ip: .host
+    }
+  end
+)
+'


### PR DESCRIPTION
Updated script uses `jq` in the MTR bash script to separate DNS names from IP addresses in the JSON data. It adds keys to the JSON data with this new data. Then the template turns that new data into macros in the discovery rule and name the generated items with DNS names.

This update makes it much easier to create graphs with the MTR data and see the DNS names of each MTR hop instead of only seeing IP addresses.

Script has been tested and works with IPv4 and IPv6. Script requires the `jq` utility to be installed on the server or proxy where it is executed. Most Linux distros come with `jq` preinstalled, but it is available for every platform.